### PR TITLE
fix: the null pointer exception of getPropertyList

### DIFF
--- a/app/src/main/java/org/autoharness/cartool/property/CarPropertyApi.kt
+++ b/app/src/main/java/org/autoharness/cartool/property/CarPropertyApi.kt
@@ -16,7 +16,7 @@ const val RESULT_SUCCESS = "success"
 interface GetPropertyList {
     fun getPropertyList(
         appFunctionContext: AppFunctionContext,
-        category: String = "ALL_CATEGORIES",
+        category: String? = "ALL_CATEGORIES",
     ): String
 }
 

--- a/app/src/main/java/org/autoharness/cartool/property/CarPropertyFunctions.kt
+++ b/app/src/main/java/org/autoharness/cartool/property/CarPropertyFunctions.kt
@@ -75,7 +75,7 @@ class CarPropertyFunctions(private val repository: CarPropertyRepository) :
                 "VEHICLE_INFO",
             ],
         )
-        category: String,
+        category: String?,
     ): String = repository.getPropertyList(category)
 
     /**

--- a/app/src/main/java/org/autoharness/cartool/property/CarPropertyRepository.kt
+++ b/app/src/main/java/org/autoharness/cartool/property/CarPropertyRepository.kt
@@ -42,8 +42,8 @@ class CarPropertyRepository(
 
     private val propertyIdByName: Map<String, Int> = allowedProperties.values.associate { it.name to it.id }
 
-    fun getPropertyList(category: String): String {
-        val allowedPropertyIds = if (category == "ALL_CATEGORIES") {
+    fun getPropertyList(category: String?): String {
+        val allowedPropertyIds = if (category == null || category == "ALL_CATEGORIES") {
             ArraySet(allowedProperties.keys)
         } else {
             val filteredKeys = allowedProperties.filterValues { it.categories.contains(category) }.keys


### PR DESCRIPTION
Although the `category` is not required, the generated `AggregatedAppFunctionInvoker.unsafeInvoke` will convert the parameter as String. This causes the NullPointerException when the caller invokes the function without `category`:
```
java.lang.NullPointerException: null cannot be cast to non-null type kotlin.String
```
Fix this issue by changing `category` as an nullable argument.

Test: Manual