### PR TITLE
feat: format property API responses as JSON strings

### DIFF
--- a/app/src/main/java/org/autoharness/cartool/property/CarPropertyApi.kt
+++ b/app/src/main/java/org/autoharness/cartool/property/CarPropertyApi.kt
@@ -45,7 +45,7 @@ interface GetBooleanProperty {
         appFunctionContext: AppFunctionContext,
         propertyName: String,
         areaId: Int,
-    ): Boolean
+    ): String
 }
 
 @AppFunctionSchemaDefinition(name = "setBooleanProperty", version = 1, category = "car-property-full")
@@ -64,7 +64,7 @@ interface GetIntProperty {
         appFunctionContext: AppFunctionContext,
         propertyName: String,
         areaId: Int,
-    ): Int
+    ): String
 }
 
 @AppFunctionSchemaDefinition(name = "setIntProperty", version = 1, category = "car-property-full")
@@ -83,7 +83,7 @@ interface GetIntArrayProperty {
         appFunctionContext: AppFunctionContext,
         propertyName: String,
         areaId: Int,
-    ): IntArray
+    ): String
 }
 
 @AppFunctionSchemaDefinition(name = "setIntArrayProperty", version = 1, category = "car-property-full")
@@ -102,7 +102,7 @@ interface GetLongProperty {
         appFunctionContext: AppFunctionContext,
         propertyName: String,
         areaId: Int,
-    ): Long
+    ): String
 }
 
 @AppFunctionSchemaDefinition(name = "setLongProperty", version = 1, category = "car-property-full")
@@ -121,7 +121,7 @@ interface GetLongArrayProperty {
         appFunctionContext: AppFunctionContext,
         propertyName: String,
         areaId: Int,
-    ): LongArray
+    ): String
 }
 
 @AppFunctionSchemaDefinition(name = "setLongArrayProperty", version = 1, category = "car-property-full")
@@ -140,7 +140,7 @@ interface GetFloatProperty {
         appFunctionContext: AppFunctionContext,
         propertyName: String,
         areaId: Int,
-    ): Float
+    ): String
 }
 
 @AppFunctionSchemaDefinition(name = "setFloatProperty", version = 1, category = "car-property-full")
@@ -159,7 +159,7 @@ interface GetFloatArrayProperty {
         appFunctionContext: AppFunctionContext,
         propertyName: String,
         areaId: Int,
-    ): FloatArray
+    ): String
 }
 
 @AppFunctionSchemaDefinition(name = "setFloatArrayProperty", version = 1, category = "car-property-full")

--- a/app/src/main/java/org/autoharness/cartool/property/CarPropertyFunctions.kt
+++ b/app/src/main/java/org/autoharness/cartool/property/CarPropertyFunctions.kt
@@ -83,7 +83,7 @@ class CarPropertyFunctions(private val repository: CarPropertyRepository) :
      *
      * @param propertyName The unique name of the vehicle property to read.
      * @param areaId The specific area ID of the property to read.
-     * @return The current string value, or an empty string if the property value is null.
+     * @return A JSON string containing propertyName, areaId, and the string value.
      */
     @AppFunction(isDescribedByKDoc = true)
     override fun getStringProperty(
@@ -98,6 +98,7 @@ class CarPropertyFunctions(private val repository: CarPropertyRepository) :
      * @param propertyName The unique name of the vehicle property to modify.
      * @param areaId The specific area ID of the property to modify.
      * @param value The new string value to set.
+     * @return A JSON string containing propertyName, areaId, and the result of the operation.
      */
     @AppFunction(isDescribedByKDoc = true)
     override fun setStringProperty(
@@ -105,24 +106,21 @@ class CarPropertyFunctions(private val repository: CarPropertyRepository) :
         propertyName: String,
         areaId: Int,
         value: String,
-    ): String {
-        repository.setStringProperty(propertyName, areaId, value)
-        return RESULT_SUCCESS
-    }
+    ): String = repository.setStringProperty(propertyName, areaId, value)
 
     /**
      * Gets the current value of a boolean type vehicle property.
      *
      * @param propertyName The unique name of the vehicle property to read.
      * @param areaId The specific area ID of the property to read.
-     * @return The current boolean value of the property.
+     * @return A JSON string containing propertyName, areaId, and the boolean value.
      */
     @AppFunction(isDescribedByKDoc = true)
     override fun getBooleanProperty(
         appFunctionContext: AppFunctionContext,
         propertyName: String,
         areaId: Int,
-    ): Boolean = repository.getBooleanProperty(propertyName, areaId)
+    ): String = repository.getBooleanProperty(propertyName, areaId)
 
     /**
      * Sets the value for a boolean type vehicle property.
@@ -130,6 +128,7 @@ class CarPropertyFunctions(private val repository: CarPropertyRepository) :
      * @param propertyName The unique name of the vehicle property to modify.
      * @param areaId The specific area ID of the property to modify.
      * @param value The new boolean value to set.
+     * @return A JSON string containing propertyName, areaId, and the result of the operation.
      */
     @AppFunction(isDescribedByKDoc = true)
     override fun setBooleanProperty(
@@ -137,24 +136,21 @@ class CarPropertyFunctions(private val repository: CarPropertyRepository) :
         propertyName: String,
         areaId: Int,
         value: Boolean,
-    ): String {
-        repository.setBooleanProperty(propertyName, areaId, value)
-        return RESULT_SUCCESS
-    }
+    ): String = repository.setBooleanProperty(propertyName, areaId, value)
 
     /**
      * Gets the current value of an integer type vehicle property.
      *
      * @param propertyName The unique name of the vehicle property to read.
      * @param areaId The specific area ID of the property to read.
-     * @return The current integer value of the property.
+     * @return A JSON string containing propertyName, areaId, and the integer value.
      */
     @AppFunction(isDescribedByKDoc = true)
     override fun getIntProperty(
         appFunctionContext: AppFunctionContext,
         propertyName: String,
         areaId: Int,
-    ): Int = repository.getIntProperty(propertyName, areaId)
+    ): String = repository.getIntProperty(propertyName, areaId)
 
     /**
      * Sets the value for an integer type vehicle property.
@@ -162,6 +158,7 @@ class CarPropertyFunctions(private val repository: CarPropertyRepository) :
      * @param propertyName The unique name of the vehicle property to modify.
      * @param areaId The specific area ID of the property to modify.
      * @param value The new integer value to set.
+     * @return A JSON string containing propertyName, areaId, and the result of the operation.
      */
     @AppFunction(isDescribedByKDoc = true)
     override fun setIntProperty(
@@ -169,24 +166,21 @@ class CarPropertyFunctions(private val repository: CarPropertyRepository) :
         propertyName: String,
         areaId: Int,
         value: Int,
-    ): String {
-        repository.setIntProperty(propertyName, areaId, value)
-        return RESULT_SUCCESS
-    }
+    ): String = repository.setIntProperty(propertyName, areaId, value)
 
     /**
      * Gets the current value of an integer array type vehicle property.
      *
      * @param propertyName The unique name of the vehicle property to read.
      * @param areaId The specific area ID of the property to read.
-     * @return The current integer array value of the property.
+     * @return A JSON string containing propertyName, areaId, and the integer array value.
      */
     @AppFunction(isDescribedByKDoc = true)
     override fun getIntArrayProperty(
         appFunctionContext: AppFunctionContext,
         propertyName: String,
         areaId: Int,
-    ): IntArray = repository.getIntArrayProperty(propertyName, areaId)
+    ): String = repository.getIntArrayProperty(propertyName, areaId)
 
     /**
      * Sets the value for an integer array type vehicle property.
@@ -194,6 +188,7 @@ class CarPropertyFunctions(private val repository: CarPropertyRepository) :
      * @param propertyName The unique name of the vehicle property to modify.
      * @param areaId The specific area ID of the property to modify.
      * @param value The new integer array value to set.
+     * @return A JSON string containing propertyName, areaId, and the result of the operation.
      */
     @AppFunction(isDescribedByKDoc = true)
     override fun setIntArrayProperty(
@@ -201,24 +196,21 @@ class CarPropertyFunctions(private val repository: CarPropertyRepository) :
         propertyName: String,
         areaId: Int,
         value: IntArray,
-    ): String {
-        repository.setIntArrayProperty(propertyName, areaId, value)
-        return RESULT_SUCCESS
-    }
+    ): String = repository.setIntArrayProperty(propertyName, areaId, value)
 
     /**
      * Gets the current value of a long type vehicle property.
      *
      * @param propertyName The unique name of the vehicle property to read.
      * @param areaId The specific area ID of the property to read.
-     * @return The current long value, or 0L if the property value is null.
+     * @return A JSON string containing propertyName, areaId, and the long value.
      */
     @AppFunction(isDescribedByKDoc = true)
     override fun getLongProperty(
         appFunctionContext: AppFunctionContext,
         propertyName: String,
         areaId: Int,
-    ): Long = repository.getLongProperty(propertyName, areaId)
+    ): String = repository.getLongProperty(propertyName, areaId)
 
     /**
      * Sets the value for a long type vehicle property.
@@ -226,6 +218,7 @@ class CarPropertyFunctions(private val repository: CarPropertyRepository) :
      * @param propertyName The unique name of the vehicle property to modify.
      * @param areaId The specific area ID of the property to modify.
      * @param value The new long value to set.
+     * @return A JSON string containing propertyName, areaId, and the result of the operation.
      */
     @AppFunction(isDescribedByKDoc = true)
     override fun setLongProperty(
@@ -233,24 +226,21 @@ class CarPropertyFunctions(private val repository: CarPropertyRepository) :
         propertyName: String,
         areaId: Int,
         value: Long,
-    ): String {
-        repository.setLongProperty(propertyName, areaId, value)
-        return RESULT_SUCCESS
-    }
+    ): String = repository.setLongProperty(propertyName, areaId, value)
 
     /**
      * Gets the current value of a long array type vehicle property.
      *
      * @param propertyName The unique name of the vehicle property to read.
      * @param areaId The specific area ID of the property to read.
-     * @return The current long array, or an empty array if the property value is null.
+     * @return A JSON string containing propertyName, areaId, and the long array value.
      */
     @AppFunction(isDescribedByKDoc = true)
     override fun getLongArrayProperty(
         appFunctionContext: AppFunctionContext,
         propertyName: String,
         areaId: Int,
-    ): LongArray = repository.getLongArrayProperty(propertyName, areaId)
+    ): String = repository.getLongArrayProperty(propertyName, areaId)
 
     /**
      * Sets the value for a long array type vehicle property.
@@ -258,6 +248,7 @@ class CarPropertyFunctions(private val repository: CarPropertyRepository) :
      * @param propertyName The unique name of the vehicle property to modify.
      * @param areaId The specific area ID of the property to modify.
      * @param value The new long array value to set.
+     * @return A JSON string containing propertyName, areaId, and the result of the operation.
      */
     @AppFunction(isDescribedByKDoc = true)
     override fun setLongArrayProperty(
@@ -265,24 +256,21 @@ class CarPropertyFunctions(private val repository: CarPropertyRepository) :
         propertyName: String,
         areaId: Int,
         value: LongArray,
-    ): String {
-        repository.setLongArrayProperty(propertyName, areaId, value)
-        return RESULT_SUCCESS
-    }
+    ): String = repository.setLongArrayProperty(propertyName, areaId, value)
 
     /**
      * Gets the current value of a float type vehicle property.
      *
      * @param propertyName The unique name of the vehicle property to read.
      * @param areaId The specific area ID of the property to read.
-     * @return The current float value of the property.
+     * @return A JSON string containing propertyName, areaId, and the float value.
      */
     @AppFunction(isDescribedByKDoc = true)
     override fun getFloatProperty(
         appFunctionContext: AppFunctionContext,
         propertyName: String,
         areaId: Int,
-    ): Float = repository.getFloatProperty(propertyName, areaId)
+    ): String = repository.getFloatProperty(propertyName, areaId)
 
     /**
      * Sets the value for a float type vehicle property.
@@ -290,6 +278,7 @@ class CarPropertyFunctions(private val repository: CarPropertyRepository) :
      * @param propertyName The unique name of the vehicle property to modify.
      * @param areaId The specific area ID of the property to modify.
      * @param value The new float value to set.
+     * @return A JSON string containing propertyName, areaId, and the result of the operation.
      */
     @AppFunction(isDescribedByKDoc = true)
     override fun setFloatProperty(
@@ -297,24 +286,21 @@ class CarPropertyFunctions(private val repository: CarPropertyRepository) :
         propertyName: String,
         areaId: Int,
         value: Float,
-    ): String {
-        repository.setFloatProperty(propertyName, areaId, value)
-        return RESULT_SUCCESS
-    }
+    ): String = repository.setFloatProperty(propertyName, areaId, value)
 
     /**
      * Gets the current value of a float array type vehicle property.
      *
      * @param propertyName The unique name of the vehicle property to read.
      * @param areaId The specific area ID of the property to read.
-     * @return The current float array, or an empty array if the property value is null.
+     * @return A JSON string containing propertyName, areaId, and the float array value.
      */
     @AppFunction(isDescribedByKDoc = true)
     override fun getFloatArrayProperty(
         appFunctionContext: AppFunctionContext,
         propertyName: String,
         areaId: Int,
-    ): FloatArray = repository.getFloatArrayProperty(propertyName, areaId)
+    ): String = repository.getFloatArrayProperty(propertyName, areaId)
 
     /**
      * Sets the value for a float array type vehicle property.
@@ -322,6 +308,7 @@ class CarPropertyFunctions(private val repository: CarPropertyRepository) :
      * @param propertyName The unique name of the vehicle property to modify.
      * @param areaId The specific area ID of the property to modify.
      * @param value The new float array value to set.
+     * @return A JSON string containing propertyName, areaId, and the result of the operation.
      */
     @AppFunction(isDescribedByKDoc = true)
     override fun setFloatArrayProperty(
@@ -329,8 +316,5 @@ class CarPropertyFunctions(private val repository: CarPropertyRepository) :
         propertyName: String,
         areaId: Int,
         value: FloatArray,
-    ): String {
-        repository.setFloatArrayProperty(propertyName, areaId, value)
-        return RESULT_SUCCESS
-    }
+    ): String = repository.setFloatArrayProperty(propertyName, areaId, value)
 }

--- a/app/src/main/java/org/autoharness/cartool/property/CarPropertyRepository.kt
+++ b/app/src/main/java/org/autoharness/cartool/property/CarPropertyRepository.kt
@@ -27,6 +27,8 @@ import org.autoharness.cartool.property.Constants.SUPPORTED_CHANGE_MODE_MAP
 import org.autoharness.cartool.property.Constants.SUPPORTED_DATA_TYPE_MAP
 import org.autoharness.cartool.property.data.AreaIdProfile
 import org.autoharness.cartool.property.data.CarPropertyProfile
+import org.autoharness.cartool.property.data.PropertyActionResult
+import org.autoharness.cartool.property.data.PropertyValueResult
 
 /**
  * A class that acts as a facade for the [CarPropertyManager].
@@ -62,13 +64,14 @@ class CarPropertyRepository(
         return Json.encodeToString(propertyProfiles)
     }
 
-    private inline fun <T> getProperty(
+    private inline fun <reified T> getProperty(
         propertyName: String,
         areaId: Int,
         block: (Int, Int) -> T,
-    ): T {
+    ): String {
         val propertyId = getPropertyIdIfAvailable(propertyName, areaId)
-        return block(propertyId, areaId)
+        val value = block(propertyId, areaId)
+        return Json.encodeToString(PropertyValueResult(propertyName, areaId, value))
     }
 
     private inline fun <T> setProperty(
@@ -76,9 +79,14 @@ class CarPropertyRepository(
         areaId: Int,
         value: T,
         block: (Int, Int, T) -> Unit,
-    ) {
+    ): String {
         val propertyId = getPropertyIdIfAvailable(propertyName)
-        block(propertyId, areaId, value)
+        return try {
+            block(propertyId, areaId, value)
+            Json.encodeToString(PropertyActionResult(propertyName, areaId, RESULT_SUCCESS))
+        } catch (e: Exception) {
+            Json.encodeToString(PropertyActionResult(propertyName, areaId, e.message ?: "Unknown error"))
+        }
     }
 
     fun getStringProperty(propertyName: String, areaId: Int): String = getProperty(propertyName, areaId) { pid, aid ->
@@ -93,7 +101,7 @@ class CarPropertyRepository(
         carPropertyManager.setProperty(String::class.java, pid, aid, v)
     }
 
-    fun getBooleanProperty(propertyName: String, areaId: Int): Boolean = getProperty(propertyName, areaId) { pid, aid ->
+    fun getBooleanProperty(propertyName: String, areaId: Int): String = getProperty(propertyName, areaId) { pid, aid ->
         carPropertyManager.getBooleanProperty(pid, aid)
     }
 
@@ -101,7 +109,7 @@ class CarPropertyRepository(
         carPropertyManager.setBooleanProperty(pid, aid, v)
     }
 
-    fun getIntProperty(propertyName: String, areaId: Int): Int = getProperty(propertyName, areaId) { pid, aid ->
+    fun getIntProperty(propertyName: String, areaId: Int): String = getProperty(propertyName, areaId) { pid, aid ->
         carPropertyManager.getIntProperty(pid, aid)
     }
 
@@ -109,7 +117,7 @@ class CarPropertyRepository(
         carPropertyManager.setIntProperty(pid, aid, v)
     }
 
-    fun getIntArrayProperty(propertyName: String, areaId: Int): IntArray = getProperty(propertyName, areaId) { pid, aid ->
+    fun getIntArrayProperty(propertyName: String, areaId: Int): String = getProperty(propertyName, areaId) { pid, aid ->
         carPropertyManager.getIntArrayProperty(pid, aid)
     }
 
@@ -117,7 +125,7 @@ class CarPropertyRepository(
         carPropertyManager.setProperty(Array<Int>::class.java, pid, aid, v.toTypedArray())
     }
 
-    fun getLongProperty(propertyName: String, areaId: Int): Long = getProperty(propertyName, areaId) { pid, aid ->
+    fun getLongProperty(propertyName: String, areaId: Int): String = getProperty(propertyName, areaId) { pid, aid ->
         carPropertyManager.getProperty(java.lang.Long::class.java, pid, aid)?.value?.toLong()
             ?: 0L
     }
@@ -126,7 +134,7 @@ class CarPropertyRepository(
         carPropertyManager.setProperty(Long::class.java, pid, aid, v)
     }
 
-    fun getLongArrayProperty(propertyName: String, areaId: Int): LongArray = getProperty(propertyName, areaId) { pid, aid ->
+    fun getLongArrayProperty(propertyName: String, areaId: Int): String = getProperty(propertyName, areaId) { pid, aid ->
         carPropertyManager.getProperty(Array<Long>::class.java, pid, aid)?.value?.toLongArray()
             ?: LongArray(0)
     }
@@ -135,7 +143,7 @@ class CarPropertyRepository(
         carPropertyManager.setProperty(Array<Long>::class.java, pid, aid, v.toTypedArray())
     }
 
-    fun getFloatProperty(propertyName: String, areaId: Int): Float = getProperty(propertyName, areaId) { pid, aid ->
+    fun getFloatProperty(propertyName: String, areaId: Int): String = getProperty(propertyName, areaId) { pid, aid ->
         carPropertyManager.getFloatProperty(pid, aid)
     }
 
@@ -143,7 +151,7 @@ class CarPropertyRepository(
         carPropertyManager.setFloatProperty(pid, aid, v)
     }
 
-    fun getFloatArrayProperty(propertyName: String, areaId: Int): FloatArray = getProperty(propertyName, areaId) { pid, aid ->
+    fun getFloatArrayProperty(propertyName: String, areaId: Int): String = getProperty(propertyName, areaId) { pid, aid ->
         carPropertyManager.getProperty(
             Array<Float>::class.java,
             pid,
@@ -264,7 +272,7 @@ class CarPropertyRepository(
             ?: throw AppFunctionInvalidArgumentException("Property '$propertyName' does not exist or is not authorized")
 
         if (areaId != null && !isPropertyAvailable(propertyId, areaId)) {
-            throw AppFunctionInvalidArgumentException("Property '$propertyName' is currently not available")
+            throw AppFunctionInvalidArgumentException("Property '$propertyName' (area: $areaId) is currently not available")
         }
         return propertyId
     }

--- a/app/src/main/java/org/autoharness/cartool/property/data/PropertyResults.kt
+++ b/app/src/main/java/org/autoharness/cartool/property/data/PropertyResults.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) The CarToolForge Authors.
+ * All rights reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+package org.autoharness.cartool.property.data
+
+import kotlinx.serialization.Serializable
+
+/**
+ * A data class representing the result of a property get operation.
+ */
+@Serializable
+data class PropertyValueResult<T>(
+    val propertyName: String,
+    val areaId: Int,
+    val value: T,
+)
+
+/**
+ * A data class representing the result of a property set operation.
+ */
+@Serializable
+data class PropertyActionResult(
+    val propertyName: String,
+    val areaId: Int,
+    val result: String,
+)

--- a/app/src/test/java/org/autoharness/cartool/property/CarPropertyRepositoryTest.kt
+++ b/app/src/test/java/org/autoharness/cartool/property/CarPropertyRepositoryTest.kt
@@ -22,6 +22,7 @@ import kotlinx.serialization.json.Json
 import org.autoharness.cartool.VehiclePropertyConfig
 import org.autoharness.cartool.property.Constants.AREA_ID_MASKS
 import org.autoharness.cartool.property.data.CarPropertyProfile
+import org.autoharness.cartool.property.data.PropertyValueResult
 import org.junit.Assert.assertArrayEquals
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
@@ -643,9 +644,20 @@ class CarPropertyRepositoryTest {
         whenever(mockCarPropertyManager.getFloatProperty(testPropId, testAreaId))
             .thenReturn(123.45f)
 
-        assertEquals(true, carPropertyRepository.getBooleanProperty(testPropName, testAreaId))
-        assertEquals(123, carPropertyRepository.getIntProperty(testPropName, testAreaId))
-        assertEquals(123.45f, carPropertyRepository.getFloatProperty(testPropName, testAreaId))
+        val boolResult = Json.decodeFromString<PropertyValueResult<Boolean>>(carPropertyRepository.getBooleanProperty(testPropName, testAreaId))
+        assertEquals(true, boolResult.value)
+        assertEquals(testPropName, boolResult.propertyName)
+        assertEquals(testAreaId, boolResult.areaId)
+
+        val intResult = Json.decodeFromString<PropertyValueResult<Int>>(carPropertyRepository.getIntProperty(testPropName, testAreaId))
+        assertEquals(123, intResult.value)
+        assertEquals(testPropName, intResult.propertyName)
+        assertEquals(testAreaId, intResult.areaId)
+
+        val floatResult = Json.decodeFromString<PropertyValueResult<Float>>(carPropertyRepository.getFloatProperty(testPropName, testAreaId))
+        assertEquals(123.45f, floatResult.value)
+        assertEquals(testPropName, floatResult.propertyName)
+        assertEquals(testAreaId, floatResult.areaId)
     }
 
     @Test
@@ -661,10 +673,17 @@ class CarPropertyRepositoryTest {
         whenever(mockCarPropertyManager.isPropertyAvailable(testPropId, testAreaId)).thenReturn(true)
         whenever(mockCarPropertyManager.getProperty(any<Class<*>>(), eq(testPropId), eq(testAreaId))).thenReturn(null)
 
-        assertEquals("", carPropertyRepository.getStringProperty(testPropName, testAreaId))
-        assertEquals(0L, carPropertyRepository.getLongProperty(testPropName, testAreaId))
-        assertArrayEquals(longArrayOf(), carPropertyRepository.getLongArrayProperty(testPropName, testAreaId))
-        assertArrayEquals(floatArrayOf(), carPropertyRepository.getFloatArrayProperty(testPropName, testAreaId), 0.0f)
+        val stringResult = Json.decodeFromString<PropertyValueResult<String>>(carPropertyRepository.getStringProperty(testPropName, testAreaId))
+        assertEquals("", stringResult.value)
+
+        val longResult = Json.decodeFromString<PropertyValueResult<Long>>(carPropertyRepository.getLongProperty(testPropName, testAreaId))
+        assertEquals(0L, longResult.value)
+
+        val longArrayResult = Json.decodeFromString<PropertyValueResult<LongArray>>(carPropertyRepository.getLongArrayProperty(testPropName, testAreaId))
+        assertArrayEquals(longArrayOf(), longArrayResult.value)
+
+        val floatArrayResult = Json.decodeFromString<PropertyValueResult<FloatArray>>(carPropertyRepository.getFloatArrayProperty(testPropName, testAreaId))
+        assertArrayEquals(floatArrayOf(), floatArrayResult.value, 0.0f)
     }
 
     @Test


### PR DESCRIPTION
Change the CarPropertyApi to return results as JSON strings for better context.
This ensures that callers can unambiguously map results to specific property and area when performing multiple parallel operations.

Test: `./gradlew clean test`